### PR TITLE
Feature tests fail to build with GCC-14 or Clang-17

### DIFF
--- a/sys/tryflock.c
+++ b/sys/tryflock.c
@@ -2,7 +2,7 @@
 #include <sys/file.h>
 #include <fcntl.h>
 
-void main()
+int main()
 {
   flock(0,LOCK_EX | LOCK_UN | LOCK_NB);
 }

--- a/sys/trygetpeereid.c
+++ b/sys/trygetpeereid.c
@@ -1,7 +1,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-void main()
+int main()
 {
   getpeereid();
 }

--- a/sys/trynamedpipebug.c
+++ b/sys/trynamedpipebug.c
@@ -2,6 +2,7 @@
 #include <fcntl.h>
 #include <sys/time.h>
 #include <unistd.h>
+#include <sys/stat.h>
 
 int main(void)
 {

--- a/sys/trypoll.c
+++ b/sys/trypoll.c
@@ -1,6 +1,7 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <poll.h>
+#include <unistd.h>
 
 int main()
 {

--- a/sys/trysendfile.c
+++ b/sys/trysendfile.c
@@ -2,7 +2,7 @@
 #include <asm/unistd.h>
 #include <unistd.h>
 
-void main(void) {
+int main(void) {
   int x;
   x = __NR_sendfile;
   sendfile(0, 1, 0, 0);

--- a/sys/trysigaction.c
+++ b/sys/trysigaction.c
@@ -1,6 +1,6 @@
 #include <signal.h>
 
-void main()
+int main()
 {
   struct sigaction sa;
   sa.sa_handler = 0;

--- a/sys/trysigprocmask.c
+++ b/sys/trysigprocmask.c
@@ -1,6 +1,6 @@
 #include <signal.h>
 
-main()
+int main()
 {
   sigset_t ss;
  

--- a/sys/tryspnam.c
+++ b/sys/tryspnam.c
@@ -1,6 +1,7 @@
 #include <shadow.h>
+#include <stdio.h>
 
-void main()
+int main()
 {
   struct spwd *spw;
 

--- a/sys/tryulong32.c
+++ b/sys/tryulong32.c
@@ -1,4 +1,6 @@
-void main()
+#include <unistd.h>
+
+int main()
 {
   unsigned long u;
   u = 1;

--- a/sys/tryulong64.c
+++ b/sys/tryulong64.c
@@ -1,4 +1,6 @@
-main()
+#include <unistd.h>
+
+int main()
 {
   unsigned long u;
   u = 1;

--- a/sys/tryunsetenv.c
+++ b/sys/tryunsetenv.c
@@ -1,5 +1,5 @@
 #include <stdlib.h>
 
-void main(void) {
+int main(void) {
   unsetenv("PATH");
 }

--- a/sys/tryuserpw.c
+++ b/sys/tryuserpw.c
@@ -1,6 +1,6 @@
 #include <userpw.h>
 
-void main()
+int main()
 {
   struct userpw *upw;
 

--- a/sys/tryvfork.c
+++ b/sys/tryvfork.c
@@ -1,4 +1,6 @@
-void main()
+#include <unistd.h>
+
+int main()
 {
   vfork();
 }

--- a/sys/trywaitp.c
+++ b/sys/trywaitp.c
@@ -1,7 +1,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
-void main()
+int main()
 {
   waitpid(0,0,0);
 }


### PR DESCRIPTION
Due to correctly detecting features removed from C99 as major source of errors Fixing includes and main signature.

Closes: #6